### PR TITLE
Adding global styling for a tags

### DIFF
--- a/packages/varnish/src/components/VarnishApp.tsx
+++ b/packages/varnish/src/components/VarnishApp.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { ThemeProvider as StyledThemeProvider } from 'styled-components';
 
+import CssBaseline from '@mui/material/CssBaseline';
 import { getTheme } from '../theme/theme';
 import { DefaultAppLayoutProvider, LayoutVariant } from './VarnishContext';
 import { ErrorBoundary } from './ErrorBoundary';
@@ -26,6 +27,7 @@ export function VarnishApp({ layout, theme, children }: VarnishAppProps) {
   return (
     <StyledThemeProvider theme={mergedTheme}>
       <ThemeProvider theme={mergedTheme}>
+        <CssBaseline />
         <ErrorBoundary>
           <DefaultAppLayoutProvider layout={layout || 'center-aligned'}>
             {children}

--- a/packages/varnish/src/theme/extended.ts
+++ b/packages/varnish/src/theme/extended.ts
@@ -6,6 +6,10 @@ export const extended = {
   background: {
     dark: color2.B5,
   },
+  link: {
+    default: color2.B3.hex,
+    contrast: color2.B2.hex,
+  },
 };
 
 export type ExtendedType = Indexable<typeof extended>;

--- a/packages/varnish/src/theme/theme.ts
+++ b/packages/varnish/src/theme/theme.ts
@@ -62,7 +62,7 @@ export const getVarnishDesignTokens = (): ThemeOptions => {
           root: ({ ownerState, theme }) => ({
             ...(ownerState.variant === 'dark'
               ? {
-                  color: extended.link.contrast,
+                  color: theme.extended.link.contrast,
                 }
               : {
                   color: theme.extended.link.default,

--- a/packages/varnish/src/theme/theme.ts
+++ b/packages/varnish/src/theme/theme.ts
@@ -53,7 +53,7 @@ export const getVarnishDesignTokens = (): ThemeOptions => {
             color: ${extended.link.default};
           }
           .linkContrast {
-            color: ${extended.link.contrast};
+            color: ${theme.extended.link.contrast};
           }
         `,
       },

--- a/packages/varnish/src/theme/theme.ts
+++ b/packages/varnish/src/theme/theme.ts
@@ -65,7 +65,7 @@ export const getVarnishDesignTokens = (): ThemeOptions => {
                   color: extended.link.contrast,
                 }
               : {
-                  color: extended.link.default,
+                  color: theme.extended.link.default,
                 }),
           }),
         },

--- a/packages/varnish/src/theme/theme.ts
+++ b/packages/varnish/src/theme/theme.ts
@@ -47,15 +47,25 @@ declare module '@mui/material/styles' {
 export const getVarnishDesignTokens = (): ThemeOptions => {
   return {
     components: {
+      MuiCssBaseline: {
+        styleOverrides: () => `
+          a {
+            color: ${extended.link.default};
+          }
+          .linkContrast {
+            color: ${extended.link.contrast};
+          }
+        `,
+      },
       MuiLink: {
         styleOverrides: {
           root: ({ ownerState }) => ({
             ...(ownerState.variant === 'dark'
               ? {
-                  color: color2.B2.hex,
+                  color: extended.link.contrast,
                 }
               : {
-                  color: color2.B3.hex,
+                  color: extended.link.default,
                 }),
           }),
         },

--- a/packages/varnish/src/theme/theme.ts
+++ b/packages/varnish/src/theme/theme.ts
@@ -59,7 +59,7 @@ export const getVarnishDesignTokens = (): ThemeOptions => {
       },
       MuiLink: {
         styleOverrides: {
-          root: ({ ownerState }) => ({
+          root: ({ ownerState, theme }) => ({
             ...(ownerState.variant === 'dark'
               ? {
                   color: extended.link.contrast,

--- a/packages/varnish/src/theme/theme.ts
+++ b/packages/varnish/src/theme/theme.ts
@@ -73,10 +73,10 @@ export const getVarnishDesignTokens = (): ThemeOptions => {
       MuiCssBaseline: {
         styleOverrides: (theme) => `
           a {
-            color: ${theme.extended.link.default};
+            color: ${theme.paletteExtended.link.default};
           }
           .linkContrast {
-            color: ${theme.extended.link.contrast};
+            color: ${theme.paletteExtended.link.contrast};
           }
         `,
       },
@@ -85,10 +85,10 @@ export const getVarnishDesignTokens = (): ThemeOptions => {
           root: ({ ownerState, theme }) => ({
             ...(ownerState.variant === 'dark'
               ? {
-                  color: theme.extended.link.contrast,
+                  color: theme.paletteExtended.link.contrast,
                 }
               : {
-                  color: theme.extended.link.default,
+                  color: theme.paletteExtended.link.default,
                 }),
           }),
         },

--- a/packages/varnish/src/theme/theme.ts
+++ b/packages/varnish/src/theme/theme.ts
@@ -48,7 +48,7 @@ export const getVarnishDesignTokens = (): ThemeOptions => {
   return {
     components: {
       MuiCssBaseline: {
-        styleOverrides: () => `
+        styleOverrides: (theme) => `
           a {
             color: ${theme.extended.link.default};
           }

--- a/packages/varnish/src/theme/theme.ts
+++ b/packages/varnish/src/theme/theme.ts
@@ -50,7 +50,7 @@ export const getVarnishDesignTokens = (): ThemeOptions => {
       MuiCssBaseline: {
         styleOverrides: () => `
           a {
-            color: ${extended.link.default};
+            color: ${theme.extended.link.default};
           }
           .linkContrast {
             color: ${theme.extended.link.contrast};


### PR DESCRIPTION
This PR adds global styling to set the color of any a tags used in Varnish 2.0, adds the link default and contrast colors to the extended palette, and adds a linkContrast class to apply to a tags for contrast styling.