### PR TITLE
Arnavic/router-documentation

### DIFF
--- a/docs/data/material/pagesVarnish.js
+++ b/docs/data/material/pagesVarnish.js
@@ -27,6 +27,7 @@ module.exports = [
     subheader: 'EXTENSIONS',
     children: [
       { pathname: '/material-ui/varnish/varnish-eslint-config', title: 'Varnish ESLint Config' },
+      { pathname: '/material-ui/varnish/varnish-with-react-router', title: 'Varnish With React Router' },
     ],
   },
 ];

--- a/docs/data/material/varnish/varnish-with-react-router/SimpleNav.js
+++ b/docs/data/material/varnish/varnish-with-react-router/SimpleNav.js
@@ -4,7 +4,7 @@
 
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { Header, VarnishApp } from '@allenai/varnish';
+import { Content, Header, VarnishApp } from '@allenai/varnish';
 
 import { BrowserRouter, NavLink } from 'react-router-dom';
 import { StaticRouter } from 'react-router-dom/server';
@@ -27,7 +27,7 @@ Router.propTypes = {
 export default function Demo() {
   return (
     <VarnishApp>
-      <div style={{ width: '100%' }}>
+      <Content>
         <Header.AI2Banner />
         <Router>
           <ul>
@@ -47,7 +47,7 @@ export default function Demo() {
             </li>
           </ul>
         </Router>
-      </div>
+      </Content>
     </VarnishApp>
   );
 }

--- a/docs/data/material/varnish/varnish-with-react-router/SimpleNav.js
+++ b/docs/data/material/varnish/varnish-with-react-router/SimpleNav.js
@@ -1,0 +1,53 @@
+/**
+ * This file has been auto-generated. Please don't edit nor review.
+ */
+
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import { Header, VarnishApp } from '@allenai/varnish';
+
+import { BrowserRouter, NavLink } from 'react-router-dom';
+import { StaticRouter } from 'react-router-dom/server';
+
+// This is something we have to do to play nicely with Material UI's docs pages.
+// This should not be needed when utilizing React Router on other web pages.
+function Router(props) {
+  const { children } = props;
+  if (typeof window === 'undefined') {
+    return <StaticRouter location="/">{children}</StaticRouter>;
+  }
+
+  return <BrowserRouter>{children}</BrowserRouter>;
+}
+
+Router.propTypes = {
+  children: PropTypes.node,
+};
+
+export default function Demo() {
+  return (
+    <VarnishApp>
+      <div style={{ width: '100%' }}>
+        <Header.AI2Banner />
+        <Router>
+          <ul>
+            <li>
+              <NavLink
+                reloadDocument
+                className={'linkContrast'}
+                to="/material-ui/getting-started/overview/"
+              >
+                To Getting Started
+              </NavLink>
+            </li>
+            <li>
+              <NavLink reloadDocument to="/material-ui/varnish/app-layout">
+                To Layout
+              </NavLink>
+            </li>
+          </ul>
+        </Router>
+      </div>
+    </VarnishApp>
+  );
+}

--- a/docs/data/material/varnish/varnish-with-react-router/SimpleNav.tsx
+++ b/docs/data/material/varnish/varnish-with-react-router/SimpleNav.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { Header, VarnishApp } from '@allenai/varnish';
+
+import { BrowserRouter, NavLink} from "react-router-dom";
+import { StaticRouter } from 'react-router-dom/server';
+
+// This is something we have to do to play nicely with Material UI's docs pages. 
+// This should not be needed when utilizing React Router on other web pages.
+function Router(props: { children?: React.ReactNode }) {
+  const { children } = props;
+  if (typeof window === 'undefined') {
+    return <StaticRouter location="/">{children}</StaticRouter>;
+  }
+
+  return <BrowserRouter>{children}</BrowserRouter>;
+}
+
+export default function Demo() {
+  return (
+    <VarnishApp>
+      <div style={{ width: '100%' }}>
+        <Header.AI2Banner />
+        <Router>
+          <ul>
+            <li>
+              <NavLink reloadDocument className={"linkContrast"} to="/material-ui/getting-started/overview/">To Getting Started</NavLink>
+            </li>
+            <li>
+              <NavLink reloadDocument to="/material-ui/varnish/app-layout">To Layout</NavLink>
+            </li>
+          </ul>
+        </Router>
+      </div>
+    </VarnishApp>
+  );
+}

--- a/docs/data/material/varnish/varnish-with-react-router/SimpleNav.tsx
+++ b/docs/data/material/varnish/varnish-with-react-router/SimpleNav.tsx
@@ -1,36 +1,36 @@
 import * as React from 'react';
-import { Header, VarnishApp } from '@allenai/varnish';
+import { Content, Header, VarnishApp } from '@allenai/varnish';
 
-import { BrowserRouter, NavLink} from "react-router-dom";
+import { BrowserRouter, NavLink } from "react-router-dom";
 import { StaticRouter } from 'react-router-dom/server';
 
 // This is something we have to do to play nicely with Material UI's docs pages. 
 // This should not be needed when utilizing React Router on other web pages.
 function Router(props: { children?: React.ReactNode }) {
-  const { children } = props;
-  if (typeof window === 'undefined') {
-    return <StaticRouter location="/">{children}</StaticRouter>;
-  }
+    const { children } = props;
+    if (typeof window === 'undefined') {
+        return <StaticRouter location="/">{children}</StaticRouter>;
+    }
 
-  return <BrowserRouter>{children}</BrowserRouter>;
+    return <BrowserRouter>{children}</BrowserRouter>;
 }
 
 export default function Demo() {
-  return (
-    <VarnishApp>
-      <div style={{ width: '100%' }}>
-        <Header.AI2Banner />
-        <Router>
-          <ul>
-            <li>
-              <NavLink reloadDocument className={"linkContrast"} to="/material-ui/getting-started/overview/">To Getting Started</NavLink>
-            </li>
-            <li>
-              <NavLink reloadDocument to="/material-ui/varnish/app-layout">To Layout</NavLink>
-            </li>
-          </ul>
-        </Router>
-      </div>
-    </VarnishApp>
-  );
+    return (
+        <VarnishApp>
+            <Content>
+                <Header.AI2Banner />
+                <Router>
+                    <ul>
+                        <li>
+                            <NavLink reloadDocument className={"linkContrast"} to="/material-ui/getting-started/overview/">To Getting Started</NavLink>
+                        </li>
+                        <li>
+                            <NavLink reloadDocument to="/material-ui/varnish/app-layout">To Layout</NavLink>
+                        </li>
+                    </ul>
+                </Router>
+            </Content>
+        </VarnishApp>
+    );
 }

--- a/docs/data/material/varnish/varnish-with-react-router/SimpleNav.tsx.preview
+++ b/docs/data/material/varnish/varnish-with-react-router/SimpleNav.tsx.preview
@@ -1,0 +1,16 @@
+{/* This file has been auto-generated. Please don't edit nor review. */}
+<VarnishApp>
+  <div style={{ width: '100%' }}>
+    <Header.AI2Banner />
+    <Router>
+      <ul>
+        <li>
+          <NavLink reloadDocument className={"linkContrast"} to="/material-ui/getting-started/overview/">To Getting Started</NavLink>
+        </li>
+        <li>
+          <NavLink reloadDocument to="/material-ui/varnish/app-layout">To Layout</NavLink>
+        </li>
+      </ul>
+    </Router>
+  </div>
+</VarnishApp>

--- a/docs/data/material/varnish/varnish-with-react-router/SimpleNav.tsx.preview
+++ b/docs/data/material/varnish/varnish-with-react-router/SimpleNav.tsx.preview
@@ -1,16 +1,16 @@
 {/* This file has been auto-generated. Please don't edit nor review. */}
 <VarnishApp>
-  <div style={{ width: '100%' }}>
-    <Header.AI2Banner />
-    <Router>
-      <ul>
-        <li>
-          <NavLink reloadDocument className={"linkContrast"} to="/material-ui/getting-started/overview/">To Getting Started</NavLink>
-        </li>
-        <li>
-          <NavLink reloadDocument to="/material-ui/varnish/app-layout">To Layout</NavLink>
-        </li>
-      </ul>
-    </Router>
-  </div>
+    <Content>
+        <Header.AI2Banner />
+        <Router>
+            <ul>
+                <li>
+                    <NavLink reloadDocument className={"linkContrast"} to="/material-ui/getting-started/overview/">To Getting Started</NavLink>
+                </li>
+                <li>
+                    <NavLink reloadDocument to="/material-ui/varnish/app-layout">To Layout</NavLink>
+                </li>
+            </ul>
+        </Router>
+    </Content>
 </VarnishApp>

--- a/docs/data/material/varnish/varnish-with-react-router/varnish-with-react-router.md
+++ b/docs/data/material/varnish/varnish-with-react-router/varnish-with-react-router.md
@@ -11,7 +11,7 @@ This is documentation for how you can use React Router in a Varnish App and inhe
 
 [React Router](https://reactrouter.com/en/main) is a tool commonly used for client-side routing. You can pull this into your Varnish App and by default get the Varnish theming for react-router links. Below is an example of how this can look when routing to pages and getting a scroll-to-top experience upon navigating to a page.
 
-The Getting Started link shows how to employ the contrast colors of Varnish links via the linkContrast class if you are using a dark theme. 
+The 'To Getting Started' example link below shows how to employ the contrast colors of Varnish links via the linkContrast class if you are using a dark theme. 
 
 ## Example
 

--- a/docs/data/material/varnish/varnish-with-react-router/varnish-with-react-router.md
+++ b/docs/data/material/varnish/varnish-with-react-router/varnish-with-react-router.md
@@ -5,7 +5,7 @@ githubLabel: 'varnish: varnish-with-react-router'
 
 # Varnish With React Router
 
-<p class="description">AI2 Varnish With React Router Usage</p>
+<p class="description">AI2 Varnish With React Router</p>
 
 This is documentation for how you can use React Router in a Varnish App and inherit Varnish theming for links.
 

--- a/docs/data/material/varnish/varnish-with-react-router/varnish-with-react-router.md
+++ b/docs/data/material/varnish/varnish-with-react-router/varnish-with-react-router.md
@@ -1,0 +1,18 @@
+---
+title: varnish-with-react-router
+githubLabel: 'varnish: varnish-with-react-router'
+---
+
+# Varnish With React Router
+
+<p class="description">AI2 Varnish With React Router Usage</p>
+
+This is documentation for how you can use React Router in a Varnish App and inherit Varnish theming for links.
+
+[React Router](https://reactrouter.com/en/main) is a tool commonly used for client-side routing. You can pull this into your Varnish App and by default get the Varnish theming for react-router links. Below is an example of how this can look when routing to pages and getting a scroll-to-top experience upon navigating to a page.
+
+The Getting Started link shows how to employ the contrast colors of Varnish links via the linkContrast class if you are using a dark theme. 
+
+## Example
+
+{{"demo": "SimpleNav.js", "bg": true}}

--- a/docs/pages/material-ui/varnish/varnish-with-react-router.js
+++ b/docs/pages/material-ui/varnish/varnish-with-react-router.js
@@ -1,0 +1,8 @@
+
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import * as pageProps from 'docs/data/material/varnish/varnish-with-react-router/varnish-with-react-router.md?@mui/markdown';
+
+export default function Page() {
+  return <MarkdownDocs {...pageProps} />;
+}


### PR DESCRIPTION
This PR adds documentation showing how to use React Router with Varnish link theming. 

The proposal with this new way of handling react-router is that we don't have a package that is shipped separately; rather, since Varnish App employs global theming, users can utilize react-router within their apps and by default they will get links styled according to our Varnish design tokens. 

This change therefore eliminates any varnish-react-router package being exported from Varnish2. 

Note: The way we are using React-Router navigation in this example has also changed from the way that varnish-react-router does things because there have been changes and upgrades with react-router v6 that made it so we cannot port over our previous usage of react-router concepts. To highlight some changes - withRouter, RouteComponentProps (which is how we get access to history) have since been deprecated. So the example in this PR does things according to react-router v6. 

Addresses Issue #15 