### PR TITLE
Adding documentation for Varnish Theme and Getting Started with Varnish

### DIFF
--- a/docs/data/material/pagesVarnish.js
+++ b/docs/data/material/pagesVarnish.js
@@ -1,5 +1,12 @@
 module.exports = [
   {
+    pathname: '/material-ui/varnish/getting-started',
+    subheader: 'DOCS',
+    children: [
+      { pathname: '/material-ui/varnish/varnish-getting-started/', title: 'Getting Started with Varnish' },
+    ],
+  },
+  {
     pathname: '/material-ui/varnish/app',
     subheader: 'APP',
     children: [

--- a/docs/data/material/pagesVarnish.js
+++ b/docs/data/material/pagesVarnish.js
@@ -3,7 +3,10 @@ module.exports = [
     pathname: '/material-ui/varnish/getting-started',
     subheader: 'DOCS',
     children: [
-      { pathname: '/material-ui/varnish/varnish-getting-started/', title: 'Getting Started with Varnish' },
+      {
+        pathname: '/material-ui/varnish/varnish-getting-started/',
+        title: 'Getting Started with Varnish',
+      },
     ],
   },
   {
@@ -26,6 +29,7 @@ module.exports = [
       { pathname: '/material-ui/varnish/footer', title: 'AI2 Footer' },
       { pathname: '/material-ui/varnish/logos', title: 'AI2 Logos' },
       { pathname: '/material-ui/varnish/colors' },
+      { pathname: '/material-ui/varnish/varnish-theme', title: 'Varnish Theme' },
       { pathname: '/material-ui/varnish/error-boundary', title: 'Error Boundary' },
     ],
   },

--- a/docs/data/material/varnish/varnish-getting-started/varnish-getting-started.md
+++ b/docs/data/material/varnish/varnish-getting-started/varnish-getting-started.md
@@ -9,7 +9,7 @@ githubLabel: 'varnish: getting-started'
 
 ## Note About Versions
 
-Older [documentation on Varnish-Deprecated](https://varnish-deprecated.allenai.org/components/table/) and [documentation on Varnish-1](https://varnish.allenai.org/components/getting_started) is still availiable. But, you should upgrade to varnish2, and if you’re not sure how, contact REVIZ.
+Older [documentation on Varnish-Deprecated](https://varnish-deprecated.allenai.org/components/table/) and [documentation on Varnish-1](https://varnish.allenai.org/components/getting_started) is still availiable. All new applications should be using varnish 2.  Upgrading older applications is non trivial. contact REVIZ if you feel this should happen.
 
 ## Getting Started
 

--- a/docs/data/material/varnish/varnish-getting-started/varnish-getting-started.md
+++ b/docs/data/material/varnish/varnish-getting-started/varnish-getting-started.md
@@ -1,0 +1,63 @@
+---
+title: Varnish - Getting Started
+githubLabel: 'varnish: getting-started'
+---
+
+# Getting Started
+
+<p class="description">Getting Started with Varnish2</p>
+
+## Note About Versions
+
+Older [documentation on Varnish-Deprecated](https://varnish-deprecated.allenai.org/components/table/) and [documentation on Varnish-1](https://varnish.allenai.org/components/getting_started) is still availiable. But, you should upgrade to varnish2, and if you’re not sure how, contact REVIZ.
+
+## Getting Started
+
+If you started your application from [Skiff Template](https://github.com/allenai/skiff-template),
+then you're already using Varnish2, as it comes installed by default.
+
+However, if you didn't, follow these steps to use `Varnish`:
+
+1.  Install `@allenai/varnish2` and all dependencies
+
+    ```sh
+    // with npm
+    npm install @allenai/varnish2
+
+    // with yarn
+    yarn add @allenai/varnish2
+    ```
+
+2.  Wrap your `<YourApp />` in the `<VarnishApp />` component:
+
+    ```jsx dark
+    import React from 'react';
+    import ReactDOM from 'react-dom';
+    import { VarnishApp } from '@allenai/varnish2';
+
+    const App = () => (
+        <VarnishApp>
+            <YourApp />
+        </VarnishApp>
+    );
+    ```
+
+3.  Now that you have Varnish installed, you can start using it to style your application.
+
+    ```jsx dark
+    import { Footer } from '@allenai/varnish2';
+
+    // use as any other React component
+    const MyComponent = () => (
+        <div>
+            <h1>👋 Hello World</h1>
+            <Footer />
+        </div>
+    );
+    ```
+
+## Material UI Components
+
+Varnish consists of a few components and many styles that are automatically applied to all
+[Material UI components](https://mui.com/components/). We encourage you to explore their
+documentation and use any component that suits you.

--- a/docs/data/material/varnish/varnish-theme/ThemeValuesDemo.js
+++ b/docs/data/material/varnish/varnish-theme/ThemeValuesDemo.js
@@ -28,8 +28,7 @@ export default function Demo() {
   };
 
   return (
-    <>
-      <List
+    <List
         sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}
         component="nav"
         aria-labelledby="nested-list-subheader"
@@ -46,6 +45,5 @@ export default function Demo() {
           </div>
         ))}
       </List>
-    </>
   );
 }

--- a/docs/data/material/varnish/varnish-theme/ThemeValuesDemo.js
+++ b/docs/data/material/varnish/varnish-theme/ThemeValuesDemo.js
@@ -1,0 +1,51 @@
+/**
+ * This file has been auto-generated. Please don't edit nor review.
+ */
+
+import * as React from 'react';
+import { getTheme } from '@allenai/varnish2';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import Collapse from '@mui/material/Collapse';
+import ExpandLess from '@mui/icons-material/ExpandLess';
+import ExpandMore from '@mui/icons-material/ExpandMore';
+
+export default function Demo() {
+  const theme = getTheme();
+  const topLevelKeys = Object.keys(theme);
+
+  const [open, setOpen] = React.useState([]);
+
+  const handleClick = (key) => {
+    if (open.includes(key)) {
+      const idx = open.indexOf(key);
+      open.splice(idx, 1);
+      setOpen([...open]);
+    } else {
+      setOpen([...open, key]);
+    }
+  };
+
+  return (
+    <>
+      <List
+        sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}
+        component="nav"
+        aria-labelledby="nested-list-subheader"
+      >
+        {topLevelKeys.map((key) => (
+          <div key={key}>
+            <ListItemButton onClick={() => handleClick(key)}>
+              <ListItemText primary={key} />
+              {open.includes(key) ? <ExpandLess /> : <ExpandMore />}
+            </ListItemButton>
+            <Collapse in={open.includes(key)} timeout="auto" unmountOnExit>
+              <pre>{JSON.stringify(theme[key], null, 2)}</pre>
+            </Collapse>
+          </div>
+        ))}
+      </List>
+    </>
+  );
+}

--- a/docs/data/material/varnish/varnish-theme/ThemeValuesDemo.js
+++ b/docs/data/material/varnish/varnish-theme/ThemeValuesDemo.js
@@ -4,46 +4,40 @@
 
 import * as React from 'react';
 import { getTheme } from '@allenai/varnish2';
-import List from '@mui/material/List';
-import ListItemButton from '@mui/material/ListItemButton';
-import ListItemText from '@mui/material/ListItemText';
-import Collapse from '@mui/material/Collapse';
-import ExpandLess from '@mui/icons-material/ExpandLess';
 import ExpandMore from '@mui/icons-material/ExpandMore';
+import { Accordion, AccordionSummary, AccordionDetails } from '@mui/material';
 
 export default function Demo() {
   const theme = getTheme();
   const topLevelKeys = Object.keys(theme);
 
-  const [open, setOpen] = React.useState([]);
-
-  const handleClick = (key) => {
-    if (open.includes(key)) {
-      const idx = open.indexOf(key);
-      open.splice(idx, 1);
-      setOpen([...open]);
-    } else {
-      setOpen([...open, key]);
-    }
-  };
-
   return (
-    <List
-      sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}
-      component="nav"
-      aria-labelledby="nested-list-subheader"
-    >
+    <div style={{ maxWidth: '100%' }}>
       {topLevelKeys.map((key) => (
-        <div key={key}>
-          <ListItemButton onClick={() => handleClick(key)}>
-            <ListItemText primary={key} />
-            {open.includes(key) ? <ExpandLess /> : <ExpandMore />}
-          </ListItemButton>
-          <Collapse in={open.includes(key)} timeout="auto" unmountOnExit>
-            <pre>{JSON.stringify(theme[key], null, 2)}</pre>
-          </Collapse>
-        </div>
+        <Accordion key={key}>
+          <AccordionSummary
+            expandIcon={<ExpandMore />}
+            aria-controls="panel1a-content"
+            id="panel1a-header"
+          >
+            {key}
+          </AccordionSummary>
+          <AccordionDetails>
+            <div
+              style={{
+                maxWidth: '90%',
+                display: 'flex',
+                flexWrap: 'wrap',
+                flexDirection: 'column',
+              }}
+            >
+              <pre style={{ whiteSpace: 'pre-wrap' }}>
+                {JSON.stringify(theme[key], null, 2)}
+              </pre>
+            </div>
+          </AccordionDetails>
+        </Accordion>
       ))}
-    </List>
+    </div>
   );
 }

--- a/docs/data/material/varnish/varnish-theme/ThemeValuesDemo.js
+++ b/docs/data/material/varnish/varnish-theme/ThemeValuesDemo.js
@@ -29,21 +29,21 @@ export default function Demo() {
 
   return (
     <List
-        sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}
-        component="nav"
-        aria-labelledby="nested-list-subheader"
-      >
-        {topLevelKeys.map((key) => (
-          <div key={key}>
-            <ListItemButton onClick={() => handleClick(key)}>
-              <ListItemText primary={key} />
-              {open.includes(key) ? <ExpandLess /> : <ExpandMore />}
-            </ListItemButton>
-            <Collapse in={open.includes(key)} timeout="auto" unmountOnExit>
-              <pre>{JSON.stringify(theme[key], null, 2)}</pre>
-            </Collapse>
-          </div>
-        ))}
-      </List>
+      sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}
+      component="nav"
+      aria-labelledby="nested-list-subheader"
+    >
+      {topLevelKeys.map((key) => (
+        <div key={key}>
+          <ListItemButton onClick={() => handleClick(key)}>
+            <ListItemText primary={key} />
+            {open.includes(key) ? <ExpandLess /> : <ExpandMore />}
+          </ListItemButton>
+          <Collapse in={open.includes(key)} timeout="auto" unmountOnExit>
+            <pre>{JSON.stringify(theme[key], null, 2)}</pre>
+          </Collapse>
+        </div>
+      ))}
+    </List>
   );
 }

--- a/docs/data/material/varnish/varnish-theme/ThemeValuesDemo.tsx
+++ b/docs/data/material/varnish/varnish-theme/ThemeValuesDemo.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { getTheme } from '@allenai/varnish2';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import Collapse from '@mui/material/Collapse';
+import ExpandLess from '@mui/icons-material/ExpandLess';
+import ExpandMore from '@mui/icons-material/ExpandMore';
+
+export default function Demo() {
+  const theme = getTheme();
+  const topLevelKeys = Object.keys(theme);
+
+  const [open, setOpen] = React.useState<string[]>([]);
+
+  const handleClick = (key: string) => {
+    if (open.includes(key)) {
+      const idx = open.indexOf(key);
+      open.splice(idx, 1);
+      setOpen([...open]);
+    } else {
+      setOpen([...open, key]);
+    }
+  };
+
+  return (
+    <>
+      <List
+        sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}
+        component="nav"
+        aria-labelledby="nested-list-subheader"
+      >
+        {topLevelKeys.map((key: string) => (
+          <div key={key}>
+            <ListItemButton onClick={() => handleClick(key)}>
+              <ListItemText primary={key} />
+              {open.includes(key) ? <ExpandLess /> : <ExpandMore />}
+            </ListItemButton>
+            <Collapse in={open.includes(key)} timeout="auto" unmountOnExit>
+              <pre>{JSON.stringify((theme as any)[key], null, 2)}</pre>
+            </Collapse>
+          </div>
+        ))}
+      </List>
+    </>
+  );
+}

--- a/docs/data/material/varnish/varnish-theme/ThemeValuesDemo.tsx
+++ b/docs/data/material/varnish/varnish-theme/ThemeValuesDemo.tsx
@@ -1,45 +1,30 @@
 import * as React from 'react';
 import { getTheme } from '@allenai/varnish2';
-import List from '@mui/material/List';
-import ListItemButton from '@mui/material/ListItemButton';
-import ListItemText from '@mui/material/ListItemText';
-import Collapse from '@mui/material/Collapse';
-import ExpandLess from '@mui/icons-material/ExpandLess';
 import ExpandMore from '@mui/icons-material/ExpandMore';
+import { Accordion, AccordionSummary, AccordionDetails } from '@mui/material';
 
 export default function Demo() {
   const theme = getTheme();
   const topLevelKeys = Object.keys(theme);
 
-  const [open, setOpen] = React.useState<string[]>([]);
-
-  const handleClick = (key: string) => {
-    if (open.includes(key)) {
-      const idx = open.indexOf(key);
-      open.splice(idx, 1);
-      setOpen([...open]);
-    } else {
-      setOpen([...open, key]);
-    }
-  };
-
   return (
-    <List
-        sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}
-        component="nav"
-        aria-labelledby="nested-list-subheader"
-      >
-        {topLevelKeys.map((key: string) => (
-          <div key={key}>
-            <ListItemButton onClick={() => handleClick(key)}>
-              <ListItemText primary={key} />
-              {open.includes(key) ? <ExpandLess /> : <ExpandMore />}
-            </ListItemButton>
-            <Collapse in={open.includes(key)} timeout="auto" unmountOnExit>
-              <pre>{JSON.stringify((theme as any)[key], null, 2)}</pre>
-            </Collapse>
-          </div>
-        ))}
-      </List>
+    <div style={{ maxWidth: '100%' }}>
+      {topLevelKeys.map((key: string) => (
+        <Accordion key={key}>
+          <AccordionSummary
+            expandIcon={<ExpandMore />}
+            aria-controls="panel1a-content"
+            id="panel1a-header"
+          >
+            {key}
+          </AccordionSummary>
+          <AccordionDetails>
+            <div style={{ maxWidth: '90%', display: 'flex', flexWrap: 'wrap', flexDirection: 'column' }} >
+              <pre style={{whiteSpace: 'pre-wrap' }}>{JSON.stringify((theme as any)[key], null, 2)}</pre>
+            </div>
+          </AccordionDetails>
+        </Accordion>
+      ))}
+    </div>
   );
 }

--- a/docs/data/material/varnish/varnish-theme/ThemeValuesDemo.tsx
+++ b/docs/data/material/varnish/varnish-theme/ThemeValuesDemo.tsx
@@ -24,8 +24,7 @@ export default function Demo() {
   };
 
   return (
-    <>
-      <List
+    <List
         sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}
         component="nav"
         aria-labelledby="nested-list-subheader"
@@ -42,6 +41,5 @@ export default function Demo() {
           </div>
         ))}
       </List>
-    </>
   );
 }

--- a/docs/data/material/varnish/varnish-theme/ThemeValuesDemo.tsx.preview
+++ b/docs/data/material/varnish/varnish-theme/ThemeValuesDemo.tsx.preview
@@ -1,0 +1,17 @@
+{/* This file has been auto-generated. Please don't edit nor review. */}
+{topLevelKeys.map((key: string) => (
+  <Accordion key={key}>
+    <AccordionSummary
+      expandIcon={<ExpandMore />}
+      aria-controls="panel1a-content"
+      id="panel1a-header"
+    >
+      {key}
+    </AccordionSummary>
+    <AccordionDetails>
+      <div style={{ maxWidth: '90%', display: 'flex', flexWrap: 'wrap', flexDirection: 'column' }} >
+        <pre style={{whiteSpace: 'pre-wrap' }}>{JSON.stringify((theme as any)[key], null, 2)}</pre>
+      </div>
+    </AccordionDetails>
+  </Accordion>
+))}

--- a/docs/data/material/varnish/varnish-theme/varnish-theme.md
+++ b/docs/data/material/varnish/varnish-theme/varnish-theme.md
@@ -22,3 +22,7 @@ const DarkBanner = styled.div`
 ## Theme Values
 
 {{"demo": "ThemeValuesDemo.js", "defaultCodeOpen": false}}
+
+## Theme in Action
+
+You can see the Theme in action in the [Typography section](/material-ui/react-typography/) and the [Varnish Colors section](/material-ui/varnish/colors/).

--- a/docs/data/material/varnish/varnish-theme/varnish-theme.md
+++ b/docs/data/material/varnish/varnish-theme/varnish-theme.md
@@ -1,0 +1,24 @@
+---
+title: Varnish Theme
+githubLabel: 'varnish: theme'
+---
+
+# Varnish Theme
+
+<p class="description">The default Varnish Theme provides programmatic access to AI2 branded colors, typography and other properties related to the user interface. Using these values helps ensure your application's look and feel matches that of other AI2 applications.</p>
+
+## Usage in a Styled Component
+
+```jsx dark
+import styled from 'styled-components';
+
+const DarkBanner = styled.div`
+  background: ${({ theme }) => theme.paletteExtended.background.dark};
+  padding: ${({ theme }) => theme.spacing(0.5)} 0;
+  line-height: 1;
+`;
+```
+
+## Theme Values
+
+{{"demo": "ThemeValuesDemo.js", "defaultCodeOpen": false}}

--- a/docs/pages/material-ui/varnish/varnish-getting-started.js
+++ b/docs/pages/material-ui/varnish/varnish-getting-started.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import * as pageProps from 'docs/data/material/varnish/varnish-getting-started/varnish-getting-started.md?@mui/markdown';
+
+export default function Page() {
+  return <MarkdownDocs {...pageProps} />;
+}

--- a/docs/pages/material-ui/varnish/varnish-theme.js
+++ b/docs/pages/material-ui/varnish/varnish-theme.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import * as pageProps from 'docs/data/material/varnish/varnish-theme/varnish-theme.md?@mui/markdown';
+
+export default function Page() {
+  return <MarkdownDocs {...pageProps} />;
+}


### PR DESCRIPTION
Addresses Issues #20 and #46 

Screenshot of the Theme docs page that shows how collapsible tabs are used to explore Theme values: 

<img width="979" alt="Screen Shot 2023-03-16 at 3 29 37 PM" src="https://user-images.githubusercontent.com/6945628/225767312-bb68d345-a4c9-44a7-9a67-54f7e220f7d0.png">
