### PR TITLE
changes to push varnish-mui to varnish endpoints

### DIFF
--- a/skiff.json
+++ b/skiff.json
@@ -1,6 +1,7 @@
 {
-  "appName": "varnish-mui",
+  "appName": "varnish",
   "contact": "jonathanb",
   "team": "reviz",
-  "replicas": { "prod": 1 }
+  "replicas": { "prod": 1 },
+  "customDomains": [ "varnish.allenai.org" ]
 }


### PR DESCRIPTION
Instructions by skjonsie for deprecating old varnish URLs and pushing varnish-mui out as the new Varnish: 

we can accomplish what's desired by:
1. deleting the varnish app, then changing appName in [skiff.json](https://github.com/allenai/varnish/blob/main/skiff.json) to varnish-deprecated; we'll want to remove customDomains too

2. deleting the varnish-mui app, then changing appName in [skiff.json](https://github.com/allenai/varnish-mui/blob/main/skiff.json#L2) to varnish and adding the customDomains property with [varnish.allenai.org](http://varnish.allenai.org/), like that seen in the current skiff.json file for varnish.

This PR is to prep for #2. 