### PR TITLE
Removing social buttons to unblock varnish publishing

### DIFF
--- a/docs/data/material/pagesVarnish.js
+++ b/docs/data/material/pagesVarnish.js
@@ -45,10 +45,6 @@ module.exports = [
         title: 'Copy To Clipboard',
       },
       { pathname: '/material-ui/varnish/max-width-text', title: 'Max Width Text' },
-      {
-        pathname: '/material-ui/varnish/social-share-buttons',
-        title: 'Social Share Buttons',
-      },
     ],
   },
   {

--- a/packages/varnish/package.json
+++ b/packages/varnish/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.20.6",
-    "@mui/icons-material": "^5.11.16",
+    "@mui/icons-material": "^5.11.11",
     "@types/react-transition-group": "^4.4.5",
     "clsx": "^1.2.1",
     "csstype": "^3.1.1",

--- a/packages/varnish/src/components/social/ShareOnFacebookButton.tsx
+++ b/packages/varnish/src/components/social/ShareOnFacebookButton.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import IconButton from '@mui/material/IconButton';
-import FacebookIcon from '@mui/icons-material/Facebook';
+// the below import is causing issues; until we get the dependency issues resolved, commenting out
+// import FacebookIcon from '@mui/icons-material/Facebook';
 
 interface Props {
   url?: string;
@@ -15,7 +16,7 @@ export function ShareOnFacebookButton({ url }: Props) {
   return (
     <IconButton aria-label="Facebook Icon" color="primary" size="small">
       <a href={myUrlWithParams.href} target="_blank" rel="noopener noreferrer">
-        <FacebookIcon />
+        {/* <FacebookIcon /> */}
       </a>
     </IconButton>
   );

--- a/packages/varnish/src/components/social/ShareOnLinkedInButton.tsx
+++ b/packages/varnish/src/components/social/ShareOnLinkedInButton.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import IconButton from '@mui/material/IconButton';
-import LinkedInIcon from '@mui/icons-material/LinkedIn';
+// the below import is causing issues; until we get the dependency issues resolved, commenting out
+// import LinkedInIcon from '@mui/icons-material/LinkedIn';
 
 interface Props {
   url?: string;
@@ -23,7 +24,7 @@ export function ShareOnLinkedInButton({ url, title, summary }: Props) {
   return (
     <IconButton aria-label="LinkedIn Icon" color="primary" size="small">
       <a href={myUrlWithParams.href} target="_blank" rel="noopener noreferrer">
-        <LinkedInIcon />
+        {/* <LinkedInIcon /> */}
       </a>
     </IconButton>
   );

--- a/packages/varnish/src/components/social/ShareOnTwitterButton.tsx
+++ b/packages/varnish/src/components/social/ShareOnTwitterButton.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import IconButton from '@mui/material/IconButton';
-import TwitterIcon from '@mui/icons-material/Twitter';
+// the below import is causing issues; until we get the dependency issues resolved, commenting out
+// import TwitterIcon from '@mui/icons-material/Twitter';
 
 interface Props {
   url?: string;
@@ -19,7 +20,7 @@ export function ShareOnTwitterButton({ url, text }: Props) {
   return (
     <IconButton aria-label="Twitter Icon" color="primary" size="small">
       <a href={myUrlWithParams.href} target="_blank" rel="noopener noreferrer">
-        <TwitterIcon />
+        {/* <TwitterIcon /> */}
       </a>
     </IconButton>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1866,13 +1866,6 @@
     react-test-renderer "^18.0.0"
     semver "^5.7.0"
 
-"@mui/icons-material@^5.11.16":
-  version "5.11.16"
-  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.11.16.tgz#417fa773c56672e39d6ccfed9ac55591985f0d38"
-  integrity sha512-oKkx9z9Kwg40NtcIajF9uOXhxiyTZrrm9nmIJ4UjkU2IdHpd4QVLbCc/5hZN/y0C6qzi2Zlxyr9TGddQx2vx2A==
-  dependencies:
-    "@babel/runtime" "^7.21.0"
-
 "@mui/x-data-grid-generator@6.0.0-alpha.14":
   version "6.0.0-alpha.14"
   resolved "https://registry.npmjs.org/@mui/x-data-grid-generator/-/x-data-grid-generator-6.0.0-alpha.14.tgz"


### PR DESCRIPTION
This PR removes the social buttons page from Varnish; we need to figure out why the material ui icons package is not resolving deps correctly. 
Creating an issue to track this -- #134 